### PR TITLE
Feature/docker ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
-language: elixir
+jobs:
+  include:
+    - stage: mix test
+      language: elixir
+      elixir:
+        - "1.8"
+      otp_release:
+        - "21.2"
+      services:
+        - postgresql
+      before_script:
+        - psql -c 'create database simplefootball_web_test;' -U postgres
+        - cp config/travis.exs config/test.exs
+        - mix do ecto.create, ecto.migrate
+      script:
+        - mix test
 
-elixir:
-  - "1.8"
-otp_release:
-  - "21.2"
-
-services:
-  - postgresql
-
-before_script:
-  - psql -c 'create database simplefootball_web_test;' -U postgres
-  - cp config/travis.exs config/test.exs
-  - mix do ecto.create, ecto.migrate
-
-script:
-  - mix test
+    - stage: docker build
+      script:
+        - docker build -t lbproductions/simplefootball_web .

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,4 +78,4 @@ WORKDIR /opt/app
 
 COPY --from=builder /opt/built .
 
-CMD env; trap 'exit' INT; /opt/app/bin/${APP_NAME} foreground
+CMD trap 'exit' INT; /opt/app/bin/${APP_NAME} foreground

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ FROM elixir:1.8-alpine AS builder
 
 # The following are build arguments used to change variable parts of the image.
 # The name of your application/release (required)
-ARG APP_NAME
+ARG APP_NAME=simplefootball_web
 # The version of the application we are building (required)
-ARG APP_VSN
+ARG APP_VSN=0.1.0
 # The environment to build with
 ARG MIX_ENV=prod
 # Set this to true if this release is not a Phoenix app
@@ -65,7 +65,7 @@ RUN \
 FROM alpine:${ALPINE_VERSION}
 
 # The name of your application/release (required)
-ARG APP_NAME
+ARG APP_NAME=simplefootball_web
 
 RUN apk update && \
     apk add --no-cache \


### PR DESCRIPTION
Hiermit prüfen wir, ob das Docker image erfolgreich gebaut werden kann.
Ich habe außerdem ein Repo auf Dockerhub angelegt: https://cloud.docker.com/repository/docker/lbproductions/simplefootball_web

Wir haben zwei Möglichkeiten, um das Image dorthin zu bekommen:
1. Travis CI bauen und dorthin pushen lassen
2. Docker Hub selber kann das Image bauen

Ich will erstmal Möglichkeit 2 probieren und habe den Hub so eingerichtet, dass er den master branch immer als `latest` image baut wenn man bei GitHub einen Tag erstellt, wird daraus ein Dockerhub Image Tag.

Was noch etwas doof ist, ist dass man im Moment an einigen Stellen die Versionsnummern increasen muss (`mix.exs`, `Dockerfile`, git tag). Das muss noch besser werden, aber erstmal nicht ^^